### PR TITLE
Allow Capybara 3.x, update spec for proper error text

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,4 +6,6 @@ AllCops:
   Exclude:
     - '*.gemspec'
     - 'vendor/**/*'
-
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/**'

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new(:spec)
 
-task default: [:spec, :rubocop]
+task default: %i[spec rubocop]

--- a/capybara_error_intel.gemspec
+++ b/capybara_error_intel.gemspec
@@ -40,5 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
 
   spec.add_runtime_dependency 'rspec', '>= 2.1', '< 4.x'
-  spec.add_runtime_dependency 'capybara', '~> 2'
+  spec.add_runtime_dependency 'capybara', '>= 2.0', '< 4.x'
 end

--- a/spec/capybara_error_intel/dsl_spec.rb
+++ b/spec/capybara_error_intel/dsl_spec.rb
@@ -25,7 +25,7 @@ describe CapybaraErrorIntel::DSL do
         expect(Example.new).to have_selector_test
       end.to raise_error(
         RSpec::Expectations::ExpectationNotMetError,
-        'expected to find css "h1" with text "test" but there were no matches. Also found "Hello", which matched the selector but not all filters.'
+        'expected to find visible css "h1" with text "test" but there were no matches. Also found "Hello", which matched the selector but not all filters.'
       )
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ if ENV['COVERAGE'] =~ /\Atrue\z/i
   SimpleCov.command_name 'Rspec'
 end
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'capybara_error_intel'
 require 'capybara/spec/spec_helper'
 


### PR DESCRIPTION
This change updates the gem to allow use with the 3.x series of
Capybara. The error raised for a missing selector now contains the word
"visible", which was the only failing spec with Capybara 3.1.