### PR TITLE
Support capybara 3.14 module rename

### DIFF
--- a/lib/capybara_error_intel/dsl.rb
+++ b/lib/capybara_error_intel/dsl.rb
@@ -52,15 +52,23 @@ module CapybaraErrorIntel
     private
 
     def has_selector(*args)
-      Capybara::RSpecMatchers::HaveSelector.new(*args)
+      capybara_matcher_module::HaveSelector.new(*args)
     end
 
     def has_text(*args)
-      Capybara::RSpecMatchers::HaveText.new(*args)
+      capybara_matcher_module::HaveText.new(*args)
     end
 
     def has_title(title, options)
-      Capybara::RSpecMatchers::HaveTitle.new(title, options)
+      capybara_matcher_module::HaveTitle.new(title, options)
+    end
+
+    def capybara_matcher_module
+      if Capybara::VERSION.to_f >= 3.14
+        Capybara::RSpecMatchers::Matchers
+      else
+        Capybara::RSpecMatchers
+      end
     end
 
     def match_or_error(matcher)

--- a/spec/capybara_error_intel/dsl_spec.rb
+++ b/spec/capybara_error_intel/dsl_spec.rb
@@ -24,8 +24,7 @@ describe CapybaraErrorIntel::DSL do
         allow(Capybara).to receive(:current_session) { '<h1>Hello</h1>' }
         expect(Example.new).to have_selector_test
       end.to raise_error(
-        RSpec::Expectations::ExpectationNotMetError,
-        'expected to find visible css "h1" with text "test" but there were no matches. Also found "Hello", which matched the selector but not all filters.'
+        /expected to find visible css "h1" with text "test" but there were no matches. Also found "Hello", which matched the selector but not all filters./
       )
     end
 


### PR DESCRIPTION
It appears Capybara pulled a fast on and re-scoped some modules in 3.14 (https://github.com/teamcapybara/capybara/commit/bfc16abbc93584e7b950761f27f3e8123c6c4793)

This is a quick fix for that issue with backwards compatibility. I debated on whether to just release a new version of Capybara Error Intel requiring `> 3.14` but that seemed a little far stretched for a minor version change.